### PR TITLE
Fix concatenated quoted unquoted arguments

### DIFF
--- a/src/parses_helper4_helper.c
+++ b/src/parses_helper4_helper.c
@@ -39,13 +39,18 @@ static int	handle_argument_token(t_arg_process_params arg_params)
 	t_consecutive_quotes_params	quote_params;
 
 	consecutive_quotes = count_consecutive_quotes(arg_params.q, arg_params.eq);
+	// First check: simple quoted string (starts and ends with same quote)
 	if ((**arg_params.q == '"' && *(*arg_params.eq - 1) == '"')
 		|| (**arg_params.q == '\'' && *(*arg_params.eq - 1) == '\''))
 	{
-		return (process_single_argument(arg_params));
+		// Only use simple processing if there's exactly one quote pair
+		// and no other content
+		if (consecutive_quotes == 1)
+			return (process_single_argument(arg_params));
 	}
-	if (consecutive_quotes > 1 && (**arg_params.q == '"'
-			||**arg_params.q == '\''))
+	// For any token with quotes (including mixed quoted/unquoted),
+	// use the concatenation logic
+	if (consecutive_quotes >= 1)
 	{
 		quote_params.ret = arg_params.ret;
 		quote_params.params = arg_params.params;
@@ -56,6 +61,7 @@ static int	handle_argument_token(t_arg_process_params arg_params)
 	}
 	else
 	{
+		// No quotes at all - simple unquoted string
 		return (process_single_argument(arg_params));
 	}
 }


### PR DESCRIPTION
Fixes argument parsing for concatenated quoted and unquoted text.

Previously, tokens like `"fwe"sdqwe` were mishandled, leading to no output, because the logic in `handle_argument_token` incorrectly routed them to `process_single_argument` which couldn't handle mixed content. The fix ensures all tokens containing quotes are processed via the concatenation logic, correctly joining quoted and unquoted segments.

---
<a href="https://cursor.com/background-agent?bcId=bc-2cb3dfb7-652e-4f55-918e-afaec3805319">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2cb3dfb7-652e-4f55-918e-afaec3805319">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

