### PR TITLE
Check for readline memory leaks

### DIFF
--- a/src/main_helper6.c
+++ b/src/main_helper6.c
@@ -61,10 +61,14 @@ int	process_single_command(char *line, char ***environ_copy)
 	result = process_command_line(line, &cmd, environ_copy);
 	if (result == 2)
 	{
+		if (line)
+			free(line);
 		cleanup_and_exit(cmd, environ_copy);
 	}
 	else if (result == 1)
 	{
+		if (line)
+			free(line);
 		return (cleanup_and_return(cmd));
 	}
 	else

--- a/src/memory_management.c
+++ b/src/memory_management.c
@@ -81,6 +81,8 @@ void	free_environ_copy(char **environ_copy)
 
 void	clean_exit(int status)
 {
+	rl_free_line_state();
+	clear_history();
 	rl_clear_history();
 	exit(status);
 }


### PR DESCRIPTION
Fixes a memory leak in command processing and adds comprehensive readline cleanup on exit.

The `line` buffer, allocated by `readline()`, was not consistently freed when `process_command_line` returned error codes (1 or 2), leading to a "definitely lost" memory leak reported by Valgrind. Additionally, `rl_free_line_state()` and `clear_history()` were added to `clean_exit()` to ensure all readline internal buffers are released, addressing "still reachable" Valgrind reports.

---
<a href="https://cursor.com/background-agent?bcId=bc-3c75b5ff-6a7f-48e1-9d70-f8974f0ce310">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3c75b5ff-6a7f-48e1-9d70-f8974f0ce310">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

